### PR TITLE
Replace ecs deploy tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,7 @@ commands:
             --timeout 1800 \
             --region $AWS_REGION \
             --image << parameters.image-name >> \
-            $CLUSTER_NAME \
-            << parameters.service-name >>
+            $CLUSTER_NAME << parameters.service-name >>
           no_output_timeout: 30m
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
             --region $AWS_REGION \
             --image << parameters.image-name >> \
             $CLUSTER_NAME \
-            << parameters.service-name >> \
+            << parameters.service-name >>
           no_output_timeout: 30m
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - deploy-env:
           service-name: 'property-api-development'
-          image-name: "$AWS_ECR_HOST/$AWS_ECR_PATH:$CIRCLE_SHA1"
+          image-tag: "$CIRCLE_SHA1"
 
   deploy-to-staging:
     docker:
@@ -82,12 +82,12 @@ jobs:
     steps:
       - deploy-env:
           service-name: 'property-api-production'
-          image-name: "$AWS_ECR_HOST/$AWS_ECR_PATH:$CIRCLE_SHA1"
+          image-tag: "$CIRCLE_SHA1"
 
 workflows:
   build-and-deploy:
       jobs:
-#      - check
+      - check
       - aws-ecr/build_and_push_image:
           name: build_and_push_image
           dockerfile: ./property-api/Dockerfile
@@ -100,44 +100,42 @@ workflows:
           tag: "${CIRCLE_SHA1}"
           filters:
             branches:
-#              only: master
-              only: replace-ecs-deploy-tool
+              only: master
 
-      - deploy-to-staging:
+      - deploy-to-development:
           requires:
-#            - check
+            - check
             - build_and_push_image
           filters:
             branches:
-#              only: master
-              only: replace-ecs-deploy-tool
+              only: master
 
-#      - permit-staging-release:
-#          type: approval
-#          requires:
-#            - deploy-to-development
-#          filters:
-#            branches:
-#              only: master
-#
-#      - deploy-to-staging:
-#          requires:
-#            - permit-staging-release
-#          filters:
-#            branches:
-#              only: master
-#
-#      - permit-production-release:
-#          type: approval
-#          requires:
-#            - deploy-to-staging
-#          filters:
-#            branches:
-#              only: master
-#
-#      - deploy-to-production:
-#          requires:
-#            - permit-production-release
-#          filters:
-#            branches:
-#              only: master
+      - permit-staging-release:
+          type: approval
+          requires:
+            - deploy-to-development
+          filters:
+            branches:
+              only: master
+
+      - deploy-to-staging:
+          requires:
+            - permit-staging-release
+          filters:
+            branches:
+              only: master
+
+      - permit-production-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: master
+
+      - deploy-to-production:
+          requires:
+            - permit-production-release
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
     parameters:
       service-name:
         type: string
-      image-name:
+      image-tag:
         type: string
     steps:
       - aws-cli/install
@@ -35,7 +35,7 @@ commands:
             --secret-access-key $AWS_SECRET_KEY \
             --timeout 1800 \
             --region $AWS_REGION \
-            --image << parameters.image-name >> \
+            --image << parameters.image-tag >> \
             $CLUSTER_NAME << parameters.service-name >>
           no_output_timeout: 30m
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - deploy-env:
           service-name: 'property-api-staging'
-          image-name: "$AWS_ECR_HOST/$AWS_ECR_PATH:$CIRCLE_SHA1"
+          image-tag: "$CIRCLE_SHA1"
 
   deploy-to-production:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,10 +86,6 @@ jobs:
 
 workflows:
   build-and-deploy:
-eam origin replace-ecs-deploy-tool
-
-lace-ecs-deploy-tool) ✗ 
-
       jobs:
 #      - check
       - aws-ecr/build_and_push_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,19 +26,18 @@ commands:
       - run:
           name: Install ecs deploy
           command: |
-              curl https://raw.githubusercontent.com/silinternational/ecs-deploy/master/ecs-deploy | sudo tee /usr/bin/ecs-deploy
-              sudo chmod +x /usr/bin/ecs-deploy
+            pip install ecs-deploy
       - run:
           name: Premote target image
           command: |
-            ecs-deploy \
-            --timeout 104400 \
+            ecs deploy \
+            --access-key-id $AWS_ID_KEY \
+            --secret-access-key $AWS_SECRET_KEY \
+            --timeout 1800 \
             --region $AWS_REGION \
-            --cluster $CLUSTER_NAME \
-            --service-name << parameters.service-name >> \
             --image << parameters.image-name >> \
-            --timeout 104400 \
-            --use-latest-task-def
+            $CLUSTER_NAME \
+            << parameters.service-name >> \
           no_output_timeout: 30m
 
 jobs:
@@ -103,40 +102,41 @@ workflows:
             branches:
               only: master
 
-      - deploy-to-development:
+      - deploy-to-staging:
           requires:
             - check
             - build_and_push_image
           filters:
             branches:
-              only: master
+#              only: master
+              only: replace-ecs-deploy-tool
 
-      - permit-staging-release:
-          type: approval
-          requires:
-            - deploy-to-development
-          filters:
-            branches:
-              only: master
-
-      - deploy-to-staging:
-          requires:
-            - permit-staging-release
-          filters:
-            branches:
-              only: master
-
-      - permit-production-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: master
-
-      - deploy-to-production:
-          requires:
-            - permit-production-release
-          filters:
-            branches:
-              only: master
+#      - permit-staging-release:
+#          type: approval
+#          requires:
+#            - deploy-to-development
+#          filters:
+#            branches:
+#              only: master
+#
+#      - deploy-to-staging:
+#          requires:
+#            - permit-staging-release
+#          filters:
+#            branches:
+#              only: master
+#
+#      - permit-production-release:
+#          type: approval
+#          requires:
+#            - deploy-to-staging
+#          filters:
+#            branches:
+#              only: master
+#
+#      - deploy-to-production:
+#          requires:
+#            - permit-production-release
+#          filters:
+#            branches:
+#              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
       - run:
           name: Install ecs deploy
           command: |
-            pip install ecs-deploy
+            sudo pip install ecs-deploy
       - run:
           name: Premote target image
           command: |
@@ -86,8 +86,12 @@ jobs:
 
 workflows:
   build-and-deploy:
+eam origin replace-ecs-deploy-tool
+
+lace-ecs-deploy-tool) ✗ 
+
       jobs:
-      - check
+#      - check
       - aws-ecr/build_and_push_image:
           name: build_and_push_image
           dockerfile: ./property-api/Dockerfile
@@ -100,11 +104,12 @@ workflows:
           tag: "${CIRCLE_SHA1}"
           filters:
             branches:
-              only: master
+#              only: master
+              only: replace-ecs-deploy-tool
 
       - deploy-to-staging:
           requires:
-            - check
+#            - check
             - build_and_push_image
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,9 @@ commands:
             --secret-access-key $AWS_SECRET_KEY \
             --timeout 1800 \
             --region $AWS_REGION \
-            --image << parameters.image-tag >> \
-            $CLUSTER_NAME << parameters.service-name >>
+            $CLUSTER_NAME \
+            << parameters.service-name >> \
+            -t << parameters.image-tag >>
           no_output_timeout: 30m
 
 jobs:


### PR DESCRIPTION
The previous ecs-deploy tool used in the ci script was affected by a bug that blocked us from keep using ci along using task definitions with parameters in the parameter store.
This tool has been replaced with a similar one that allows us to keep using ci https://github.com/fabfuel/ecs-deploy
